### PR TITLE
Add default users service route

### DIFF
--- a/docker_settings_init.sh
+++ b/docker_settings_init.sh
@@ -81,7 +81,7 @@ groot_config="package config
 
 const RecruiterToken string = \"\"
 const CrowdPrefix = \"Basic \"
-const CrowdURL string = \"\"
+const CrowdURL string = \"http://localhost:8001/users\"
 const CrowdToken string = \"\"
 
 const AccessLogLocation string = \"log/access.log\"


### PR DESCRIPTION
- Adds `http://localhost:8001/users` as default crowd route

- Equivalent of https://github.com/acm-uiuc/groot/commit/c937da30a61be3efcaaebabb32e6d8169caa3323